### PR TITLE
set up docker, and enviroment vaiables locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM rabbitmq:3.8.0-management
+
+COPY rabbitmq.conf /etc/rabbitmq/
+
+ENV RABBITMQ_NODENAME=rabbit@localhost
+
+RUN chown rabbitmq:rabbitmq /etc/rabbitmq/rabbitmq.conf
+
+USER rabbitmq:rabbitmq

--- a/rabbitmq.conf
+++ b/rabbitmq.conf
@@ -1,0 +1,4 @@
+loopback_users.guest = false
+listeners.tcp.default = 5672
+management.tcp.port = 15672
+management.tcp.ip = 0.0.0.0

--- a/rabbitmq.dev.conf
+++ b/rabbitmq.dev.conf
@@ -1,0 +1,4 @@
+loopback_users.guest = false
+listeners.tcp.default = 5672
+management.tcp.port = 15672
+# management.tcp.ip = 0.0.0.0 // turn on for prod

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,8 @@
+services:
+- type: web
+  name: rabbitmq
+  env: docker
+  disk:
+    name: rabbitmq
+    mountPath: /var/lib/rabbitmq
+    sizeGB: 10


### PR DESCRIPTION
This pull request introduces RabbitMQ as a service in the project by adding its configuration, Docker setup, and deployment specifications. The most important changes include the creation of a `Dockerfile` for RabbitMQ, configuration files for production and development environments, and deployment details in `render.yaml`.

### RabbitMQ Docker Setup:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R9): Added a Dockerfile to set up RabbitMQ using the `rabbitmq:3.8.0-management` image, configured the node name, and set permissions for the configuration file.

### RabbitMQ Configuration:
* [`rabbitmq.conf`](diffhunk://#diff-4e0c304f43304dd5cc40b1861f49ec1d9ff2e4cb6bf0bc431bc8de4ee2f7d68eR1-R4): Added production configuration for RabbitMQ, including disabling loopback users and specifying TCP listener and management ports.
* [`rabbitmq.dev.conf`](diffhunk://#diff-24f32a004fa0333e496ec01c4870050be07841f654a9218181b6cf73dc205d41R1-R4): Added development configuration for RabbitMQ with similar settings, but commented out the management IP for production use.

### Deployment Specification:
* [`render.yaml`](diffhunk://#diff-a64cf250b418ab8feee6c682a3d8cbd3b72cf24d4a241adeaf35c98b84045f93R1-R8): Defined deployment details for RabbitMQ as a web service, including environment setup, disk configuration, and mount path.