### PR TITLE
initial setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,7 @@ ENV RABBITMQ_NODENAME=rabbit@localhost
 RUN chown rabbitmq:rabbitmq /etc/rabbitmq/rabbitmq.conf
 
 USER rabbitmq:rabbitmq
+
+# Add health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD rabbitmq-diagnostics -q ping

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ COPY rabbitmq.conf /etc/rabbitmq/
 
 ENV RABBITMQ_NODENAME=rabbit@localhost
 
+EXPOSE 5672 15672
+
 RUN chown rabbitmq:rabbitmq /etc/rabbitmq/rabbitmq.conf
 
 USER rabbitmq:rabbitmq

--- a/render.yaml
+++ b/render.yaml
@@ -3,13 +3,13 @@ services:
   name: rabbitmq
   env: docker
   port: 15672
-  # envVars:
-  # - key: RABBITMQ_ERLANG_COOKIE
-  #   generateValue: true
-  # - key: RABBITMQ_DEFAULT_USER
-  #   value: rabbitmq
-  # - key: RABBITMQ_DEFAULT_PASS
-  #   generateValue: true
+  envVars:
+  - key: RABBITMQ_ERLANG_COOKIE
+    generateValue: true
+  - key: RABBITMQ_DEFAULT_USER
+    value: rabbitmq
+  - key: RABBITMQ_DEFAULT_PASS
+    generateValue: true
   disk:
     name: rabbitmq
     mountPath: /var/lib/rabbitmq

--- a/render.yaml
+++ b/render.yaml
@@ -4,11 +4,11 @@ services:
   env: docker
   port: 15672
   envVars:
-  - key: RABBITMQ_ERLANG_COOKIE
-    generateValue: true
   - key: RABBITMQ_DEFAULT_USER
-    value: rabbitmq
+    value: admin
   - key: RABBITMQ_DEFAULT_PASS
+    generateValue: true
+  - key: RABBITMQ_ERLANG_COOKIE
     generateValue: true
   disk:
     name: rabbitmq

--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,16 @@ services:
 - type: web
   name: rabbitmq
   env: docker
+  port: 15672
+  # envVars:
+  # - key: RABBITMQ_ERLANG_COOKIE
+  #   generateValue: true
+  # - key: RABBITMQ_DEFAULT_USER
+  #   value: rabbitmq
+  # - key: RABBITMQ_DEFAULT_PASS
+  #   generateValue: true
   disk:
     name: rabbitmq
     mountPath: /var/lib/rabbitmq
     sizeGB: 10
+  healthCheckPath: /api/health


### PR DESCRIPTION
This pull request introduces several updates to enhance the RabbitMQ Docker setup and deployment configuration. The most significant changes include exposing additional ports, adding a health check to the Dockerfile, and configuring environment variables and a health check path in the deployment configuration.

### Dockerfile updates:
* Added `EXPOSE 5672 15672` to expose the RabbitMQ default and management plugin ports.
* Introduced a health check using `rabbitmq-diagnostics -q ping` with specified intervals, timeouts, and retries for better container monitoring.

### Deployment configuration updates:
* Added `port: 15672` to the RabbitMQ service in `render.yaml` to match the exposed management plugin port.
* Configured environment variables for RabbitMQ, including `RABBITMQ_DEFAULT_USER`, `RABBITMQ_DEFAULT_PASS` (with auto-generated values), and `RABBITMQ_ERLANG_COOKIE` for secure communication.
* Added `healthCheckPath: /api/health` to enable health monitoring for the RabbitMQ service.