### PR TITLE
change rabbitmq to private service on render

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,8 +1,7 @@
 services:
-- type: web
+- type: pserv  # Change to private service
   name: rabbitmq
   env: docker
-  port: 15672
   disk:
     name: rabbitmq
     mountPath: /var/lib/rabbitmq


### PR DESCRIPTION
This pull request includes a small change to the `render.yaml` file. The change updates the service type for RabbitMQ from `web` to `pserv` to indicate that it is now a private service and removes the `port` configuration.